### PR TITLE
fix(a11y): add aria label to icon button

### DIFF
--- a/src/calendar/icon-button.vue
+++ b/src/calendar/icon-button.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     type="button"
+    :aria-label="ariaLabel"
     :disabled="disabled"
     :class="[
       `${prefixClass}-btn ${prefixClass}-btn-text ${prefixClass}-btn-icon-${type}`,
@@ -17,6 +18,7 @@
 <script>
 export default {
   props: {
+    ariaLabel: String,
     type: String,
     disabled: Boolean,
   },

--- a/src/calendar/table-date.vue
+++ b/src/calendar/table-date.vue
@@ -3,23 +3,15 @@
     <div :class="`${prefixClass}-calendar-header`">
       <icon-button
         type="double-left"
+        :aria-label="locale.prevYear"
         :disabled="isDisabledArrows('last-year')"
         @click="handleIconDoubleLeftClick"
       ></icon-button>
       <icon-button
         type="left"
+        :aria-label="locale.prevMonth"
         :disabled="isDisabledArrows('last-month')"
         @click="handleIconLeftClick"
-      ></icon-button>
-      <icon-button
-        type="double-right"
-        :disabled="isDisabledArrows('next-year')"
-        @click="handleIconDoubleRightClick"
-      ></icon-button>
-      <icon-button
-        type="right"
-        :disabled="isDisabledArrows('next-month')"
-        @click="handleIconRightClick"
       ></icon-button>
       <span :class="`${prefixClass}-calendar-header-label`">
         <button
@@ -34,6 +26,18 @@
           {{ item.label }}
         </button>
       </span>
+      <icon-button
+        type="right"
+        :aria-label="locale.nextMonth"
+        :disabled="isDisabledArrows('next-month')"
+        @click="handleIconRightClick"
+      ></icon-button>
+      <icon-button
+        type="double-right"
+        :aria-label="locale.nextYear"
+        :disabled="isDisabledArrows('next-year')"
+        @click="handleIconDoubleRightClick"
+      ></icon-button>
     </div>
     <div :class="`${prefixClass}-calendar-content`">
       <table :class="`${prefixClass}-table ${prefixClass}-table-date`">
@@ -158,6 +162,9 @@ export default {
         month,
       });
       return chunk(arr, 7);
+    },
+    locale() {
+      return this.getLocale();
     },
   },
   methods: {

--- a/src/calendar/table-month.vue
+++ b/src/calendar/table-month.vue
@@ -3,13 +3,9 @@
     <div :class="`${prefixClass}-calendar-header`">
       <icon-button
         type="double-left"
+        :aria-label="locale.prev"
         :disabled="isDisabledArrows('last-year')"
         @click="handleIconDoubleLeftClick"
-      ></icon-button>
-      <icon-button
-        type="double-right"
-        :disabled="isDisabledArrows('next-year')"
-        @click="handleIconDoubleRightClick"
       ></icon-button>
       <span :class="`${prefixClass}-calendar-header-label`">
         <button
@@ -20,6 +16,12 @@
           {{ calendarYear }}
         </button>
       </span>
+      <icon-button
+        type="double-right"
+        :aria-label="locale.next"
+        :disabled="isDisabledArrows('next-year')"
+        @click="handleIconDoubleRightClick"
+      ></icon-button>
     </div>
     <div :class="`${prefixClass}-calendar-content`">
       <table :class="`${prefixClass}-table ${prefixClass}-table-month`" @click="handleClick">
@@ -81,6 +83,9 @@ export default {
         return { text, month };
       });
       return chunk(months, 3);
+    },
+    locale() {
+      return this.getLocale();
     },
   },
   methods: {

--- a/src/calendar/table-year.vue
+++ b/src/calendar/table-year.vue
@@ -3,19 +3,21 @@
     <div :class="`${prefixClass}-calendar-header`">
       <icon-button
         type="double-left"
+        :aria-label="locale.prev"
         :disabled="isDisabledArrows('last-decade')"
         @click="handleIconDoubleLeftClick"
-      ></icon-button>
-      <icon-button
-        type="double-right"
-        :disabled="isDisabledArrows('next-decade')"
-        @click="handleIconDoubleRightClick"
       ></icon-button>
       <span :class="`${prefixClass}-calendar-header-label`">
         <span>{{ firstYear }}</span>
         <span :class="`${prefixClass}-calendar-decade-separator`"></span>
         <span>{{ lastYear }}</span>
       </span>
+      <icon-button
+        type="double-right"
+        :aria-label="locale.next"
+        :disabled="isDisabledArrows('next-decade')"
+        @click="handleIconDoubleRightClick"
+      ></icon-button>
     </div>
     <div :class="`${prefixClass}-calendar-content`">
       <table :class="`${prefixClass}-table ${prefixClass}-table-year`" @click="handleClick">
@@ -39,11 +41,15 @@
 import IconButton from './icon-button';
 import { chunk } from '../util/base';
 import { setYear } from '../util/date';
+import { getLocale } from '../locale';
 
 export default {
   name: 'TableYear',
   components: { IconButton },
   inject: {
+    getLocale: {
+      default: () => getLocale,
+    },
     prefixClass: {
       default: 'mx',
     },
@@ -79,6 +85,9 @@ export default {
     lastYear() {
       const last = arr => arr[arr.length - 1];
       return last(last(this.years));
+    },
+    locale() {
+      return this.getLocale();
     },
   },
   methods: {

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -5,6 +5,12 @@ const lang = {
   yearFormat: 'YYYY',
   monthFormat: 'MMM',
   monthBeforeYear: true,
+  next: 'Next Page',
+  prev: 'Previous Page',
+  nextYear: 'Next Year',
+  prevMonth: 'Previous Month',
+  nextMonth: 'Next Month',
+  prevYear: 'Previous Year',
 };
 
 export default lang;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -154,15 +154,8 @@
   line-height: 34px;
   text-align: center;
   overflow: hidden;
-}
-
-.#{$namespace}-btn-icon-left,
-.#{$namespace}-btn-icon-double-left {
-  float: left;
-}
-.#{$namespace}-btn-icon-right,
-.#{$namespace}-btn-icon-double-right {
-  float: right;
+  display: flex;
+  justify-content: space-between;
 }
 
 .#{$namespace}-calendar-header-label {
@@ -199,6 +192,9 @@
       cursor: not-allowed;
       color: $disabled-color;
       background-color: $disabled-background-color;
+    }
+    &.focus {
+      outline: -webkit-focus-ring-color auto 1px;
     }
   }
 }


### PR DESCRIPTION
Added aria-label to allow screen readers to reach some icon buttons 

before: 
![Screenshot 2023-10-16 at 21 12 42](https://github.com/mengxiong10/vue2-datepicker/assets/15335574/e9d28cb4-d8af-422a-b10a-4cdd9a1520d3)

after: 
![Screenshot 2023-10-16 at 21 14 05](https://github.com/mengxiong10/vue2-datepicker/assets/15335574/ae3e90c4-e4f7-4c71-893a-1e143ae6c024)